### PR TITLE
Fixed missing header data in the zmq layer.

### DIFF
--- a/zmqoutput.c
+++ b/zmqoutput.c
@@ -67,7 +67,7 @@ int zmqoutput_write_byte(Bit_stream_struc *bs, unsigned char data)
 
         memcpy(txframe, zmqbuf, zmqbuf_len);
 
-        int send_error = zmq_send(bs->zmq_sock, txframe, frame_length,
+        int send_error = zmq_send(bs->zmq_sock, header, frame_length,
                 ZMQ_DONTWAIT);
 
         if (send_error < 0) {


### PR DESCRIPTION
The header information was missing due to using the wrong pointer in zmq_send. It also added 12 undefined bytes at the end of the payload.

Because it is an optional header on the receiving end in the ODR-DabMux, I guess it goes fairly un-noticed, except possibly for the 12 extra bytes at the end. I don't use the ODR-DabMux at the moment, so I don't know if it causes any audible glitches.