### PR TITLE
Update to build with g++ on linux and cygwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ ENABLE_INPUT_VLC=1
 # Set this to 0 to disable compiling the JACK input
 ENABLE_INPUT_JACK=1
 
+# use gcc or g++, on windows/cygwin use g++ to link with zmq
 CC = gcc
 
 HEADERS = \

--- a/README
+++ b/README
@@ -96,7 +96,7 @@ Output Options
         'j' joint stereo
         'm' mono
 
-    -p [int]
+    -y [int]
         which psy model to use (default '1')
         Different models for the psychoacoustics
         Models: -1 to 4
@@ -149,14 +149,14 @@ EXAMPLES
     and using the default psychoacoustic model (model 1)
 
 2.
-    toolame -p 2 -v 5 sound.wav newfile.mp2
+    toolame -y 2 -v 5 sound.wav newfile.mp2
 
     Encode sound.wav to newfile.mp2 using psychoacoustic model 2 and encoding
     with variable bitrate. The high value of the "-v" argument means that
     the encoding will tend to favour higher bitrates.
 
 3.
-    toolame -p 2 -v -5 sound.wav newfile.mp2
+    toolame -y 2 -v -5 sound.wav newfile.mp2
 
     Same as example above, except that the negative value of the "-v" argument
     means that the lower bitrates will be favoured over the higher ones.
@@ -223,6 +223,9 @@ Matthias P. Braendli <matthias@mpb.li>
     ZeroMQ output for ODR-DabMux
     PAD insertion for DLS and slides
     JACK and libVLC input
+
+data path <|)/\T/\2P/\T|-|@G|\/|/\||_.(()|\/|>
+    update to build with g++ on linux and windows cygwin (g++ needed to link with ZeroMQ on cygwin)
 
 *********************
 REFERENCE PAPERS

--- a/audio_read.c
+++ b/audio_read.c
@@ -134,8 +134,8 @@ int process(jack_nframes_t nframes, void *arg) {
     //jack_thread_info_t *info = (jack_thread_info_t *) arg;
 
     jack_default_audio_sample_t *in_left, *in_right;
-    in_left = jack_port_get_buffer(input_port_left, nframes);
-    in_right = jack_port_get_buffer(input_port_right, nframes);
+    in_left = (jack_default_audio_sample_t *)jack_port_get_buffer(input_port_left, nframes);
+    in_right = (jack_default_audio_sample_t *)jack_port_get_buffer(input_port_right, nframes);
 
     /* Sndfile requires interleaved data.  It is simpler here to
      * just queue interleaved samples to a single ringbuffer. */
@@ -222,7 +222,7 @@ unsigned long read_samples (music_in_t* musicin, short sample_buffer[2304],
         }
 
         jack_sample_buffer = malloc(f * (int)samples_read);
-        int bytes_read = jack_ringbuffer_read(rb, jack_sample_buffer, f * (int)samples_read);
+        int bytes_read = jack_ringbuffer_read(rb, (char *)jack_sample_buffer, f * (int)samples_read);
         //fprintf(stderr, " read_bytes / f = %d, should be %d\n", (int)bytes_read/f, samples_read);
         samples_read = bytes_read / f;
         if (bytes_read % f != 0) {

--- a/audio_read.h
+++ b/audio_read.h
@@ -28,9 +28,11 @@ typedef struct IFF_AIFF_struct
 }
 IFF_AIFF;
 
+#if defined(JACK_INPUT)
 void setup_jack(frame_header *header, const char* jackname);
 int process(jack_nframes_t nframes, void *arg);
 void jack_shutdown(void *arg);
+#endif
 
 void parse_input_file (FILE *musicin, char *, frame_header *header, unsigned long *num_samples);
 void aiff_check (char *file_name, IFF_AIFF * pcm_aiff_data, int *version);

--- a/common.h
+++ b/common.h
@@ -89,7 +89,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(JACK_INPUT)
 #include <jack/jack.h>
+#endif
 
 /* Structure for Reading Layer II Allocation Tables from File */
 
@@ -169,8 +171,10 @@ typedef struct music_in_s
     /* Data for the wav input */
     FILE* wav_input;
 
+#if defined(JACK_INPUT)
     /* Data for the jack input */
     jack_client_t* jack_client;
+#endif
     const char*    jack_name;
 } music_in_t;
 

--- a/encode.c
+++ b/encode.c
@@ -211,7 +211,7 @@ void transmission_pattern (unsigned int scalar[2][3][SBLIMIT],
   int nch = frame->nch;
   int sblimit = frame->sblimit;
   int dscf[2];
-  int class[2], i, j, k;
+  int klass[2], i, j, k;
   static int pattern[5][5] = { {0x123, 0x122, 0x122, 0x133, 0x123},
   {0x113, 0x111, 0x111, 0x444, 0x113},
   {0x111, 0x111, 0x111, 0x333, 0x113},
@@ -225,17 +225,17 @@ void transmission_pattern (unsigned int scalar[2][3][SBLIMIT],
       dscf[1] = (scalar[k][1][i] - scalar[k][2][i]);
       for (j = 0; j < 2; j++) {
 	if (dscf[j] <= -3)
-	  class[j] = 0;
+	  klass[j] = 0;
 	else if (dscf[j] > -3 && dscf[j] < 0)
-	  class[j] = 1;
+	  klass[j] = 1;
 	else if (dscf[j] == 0)
-	  class[j] = 2;
+	  klass[j] = 2;
 	else if (dscf[j] > 0 && dscf[j] < 3)
-	  class[j] = 3;
+	  klass[j] = 3;
 	else
-	  class[j] = 4;
+	  klass[j] = 4;
       }
-      switch (pattern[class[0]][class[1]]) {
+      switch (pattern[klass[0]][klass[1]]) {
       case 0x123:
 	scfsi[k][i] = 0;
 	break;

--- a/encode_new.c
+++ b/encode_new.c
@@ -292,7 +292,7 @@ void sf_transmission_pattern (unsigned int sf_index[2][3][SBLIMIT],
   int nch = frame->nch;
   int sblimit = frame->sblimit;
   int dscf[2];
-  int class[2], i, j, k;
+  int klass[2], i, j, k;
   static int pattern[5][5] = { {0x123, 0x122, 0x122, 0x133, 0x123},
   {0x113, 0x111, 0x111, 0x444, 0x113},
   {0x111, 0x111, 0x111, 0x333, 0x113},
@@ -306,17 +306,17 @@ void sf_transmission_pattern (unsigned int sf_index[2][3][SBLIMIT],
       dscf[1] = (sf_index[k][1][i] - sf_index[k][2][i]);
       for (j = 0; j < 2; j++) {
 	if (dscf[j] <= -3)
-	  class[j] = 0;
+	  klass[j] = 0;
 	else if (dscf[j] > -3 && dscf[j] < 0)
-	  class[j] = 1;
+	  klass[j] = 1;
 	else if (dscf[j] == 0)
-	  class[j] = 2;
+	  klass[j] = 2;
 	else if (dscf[j] > 0 && dscf[j] < 3)
-	  class[j] = 3;
+	  klass[j] = 3;
 	else
-	  class[j] = 4;
+	  klass[j] = 4;
       }
-      switch (pattern[class[0]][class[1]]) {
+      switch (pattern[klass[0]][klass[1]]) {
       case 0x123:
 	sf_selectinfo[k][i] = 0;
 	break;

--- a/html/readme.html
+++ b/html/readme.html
@@ -98,7 +98,7 @@ Output Options
 		'j' joint stereo
 		'm' mono
 
-	-p [int]
+	-y [int]
 		which psy model to use (default '1')
 		Different models for the psychoacoustics
 	        Models: -1 to 4
@@ -150,14 +150,14 @@ Misc
 	and using the default psychoacoustic model (model 1)</p>
 
 <pre>
-	toolame -p 2 -v 5 sound.wav newfile.mp2
+	toolame -y 2 -v 5 sound.wav newfile.mp2
 </pre>
 	Encode sound.wav to newfile.mp2 using psychoacoustic model 2 and encoding
 	with variable bitrate. The high value of the "-v" argument means that 
 	the encoding will tend to favour higher bitrates.</p>
 
 <pre>
-	toolame -p 2 -v -5 sound.wav newfile.mp2
+	toolame -y 2 -v -5 sound.wav newfile.mp2
 </pre>
 	Same as example above, except that the negative value of the "-v" argument
 	means that the lower bitrates will be favoured over the higher ones.</p>
@@ -202,6 +202,8 @@ Misc
 <LI> Nicolas Croiset - ncroiset at vdl.fr - DAB length control, ignore 4GB limit when reading from stdin, fixed bitstream ending to allow concatenation of mp2 files, fixes for psycho1 model [02k]
 
 <LI> Mike Cheng mikecheng at NOT planckenergy.com - Most of the rest 
+
+<LI> data path - Update to build with g++ on linux and windows cygwin (g++ needed to link with ZeroMQ on cygwin)
 
 </UL>
 

--- a/ieeefloat.c
+++ b/ieeefloat.c
@@ -57,8 +57,7 @@
 # define FloatToUnsigned(f)	((unsigned long)(((long)((f) - 2147483648.0)) + 2147483647L + 1))
 # define UnsignedToFloat(u)	(((double)((long)((u) - 2147483647L - 1))) + 2147483648.0)
 
-double ConvertFromIeeeExtended (bytes)
-     char *bytes;
+double ConvertFromIeeeExtended (char *bytes)
 {
   double f;
   long expon;

--- a/musicin.h
+++ b/musicin.h
@@ -25,7 +25,7 @@
 
 extern int cont_flag;
 
-#define e              2.71828182845
+//#define e              2.71828182845
 
 #define CBLIMIT       21
 

--- a/options.h
+++ b/options.h
@@ -25,6 +25,6 @@ typedef struct
 }
 options;
 
-options glopts;
+extern options glopts;
 #endif
 

--- a/portableio.c
+++ b/portableio.c
@@ -59,8 +59,7 @@
 /****************************************************************
  * Big/little-endian independent I/O routines.
  ****************************************************************/
-int Read16BitsHighLow (fp)
-     FILE *fp;
+int Read16BitsHighLow (FILE *fp)
 {
   int first, second, result;
 
@@ -75,8 +74,7 @@ int Read16BitsHighLow (fp)
   return (result);
 }
 
-double ReadIeeeExtendedHighLow (fp)
-     FILE *fp;
+double ReadIeeeExtendedHighLow (FILE *fp)
 {
   char bits[kExtendedLength];
 
@@ -84,8 +82,7 @@ double ReadIeeeExtendedHighLow (fp)
   return ConvertFromIeeeExtended (bits);
 }
 
-int Read32BitsHighLow (fp)
-     FILE *fp;
+int Read32BitsHighLow (FILE *fp)
 {
   int first, second, result;
 
@@ -100,10 +97,7 @@ int Read32BitsHighLow (fp)
   return (result);
 }
 
-void ReadBytes (fp, p, n)
-     FILE *fp;
-     char *p;
-     int n;
+void ReadBytes (FILE *fp, char *p, int n)
 {
   while (!feof (fp) & (n-- > 0))
     *p++ = getc (fp);

--- a/psycho_1.c
+++ b/psycho_1.c
@@ -122,9 +122,9 @@ void psycho_1_read_cbound (int lay, int freq)
   }
 }
 
-void psycho_1_read_freq_band (ltg, lay, freq)	/* this function reads in   */
-     int lay, freq;		/* frequency bands and bark */
-     g_ptr *ltg;		/* values                   */
+/*     int lay, freq;*/		/* frequency bands and bark */
+/*     g_ptr *ltg;   */		/* values                   */
+void psycho_1_read_freq_band (g_ptr *ltg, int lay, int freq)	/* this function reads in   */
 {
 
 #include "freqtable.h"

--- a/psycho_2.c
+++ b/psycho_2.c
@@ -8,12 +8,12 @@
 #include "fft.h"
 #include "psycho_2.h"
 
-/* The static variables "r", "phi_sav", "new", "old" and "oldest" have    */
+/* The static variables "r", "phi_sav", "fresh", "old" and "oldest" have    */
 /* to be remembered for the unpredictability measure.  For "r" and        */
 /* "phi_sav", the first index from the left is the channel select and     */
 /* the second index is the "age" of the data.                             */
 
-static int new = 0, old = 1, oldest = 0;
+static int fresh = 0, old = 1, oldest = 0;
 static int init = 0, flush, sync_flush, syncsize, sfreq_idx;
 
 /* The following static variables are constants.                           */
@@ -96,11 +96,11 @@ void psycho_2 (short int *buffer, short int savebuf[1056], int chn,
     /*for layer 1 computations, for the layer 2 double computations, the pointers */
     /*are reset automatically on the second pass                                 */
     {
-      if (new == 0) {
-	new = 1;
+      if (fresh == 0) {
+	fresh = 1;
 	oldest = 1;
       } else {
-	new = 0;
+	fresh = 0;
 	oldest = 0;
       }
       if (old == 0)
@@ -111,8 +111,8 @@ void psycho_2 (short int *buffer, short int savebuf[1056], int chn,
     for (j = 0; j < HBLKSIZE; j++) {
       r_prime = 2.0 * r[chn][old][j] - r[chn][oldest][j];
       phi_prime = 2.0 * phi_sav[chn][old][j] - phi_sav[chn][oldest][j];
-      r[chn][new][j] = sqrt ((double) energy[j]);
-      phi_sav[chn][new][j] = phi[j];
+      r[chn][fresh][j] = sqrt ((double) energy[j]);
+      phi_sav[chn][fresh][j] = phi[j];
 #ifdef SINCOS
       {
 	// 12% faster
@@ -120,19 +120,19 @@ void psycho_2 (short int *buffer, short int savebuf[1056], int chn,
 	double sphi, cphi, sprime, cprime;
 	__sincos ((double) phi[j], &sphi, &cphi);
 	__sincos ((double) phi_prime, &sprime, &cprime);
-	temp1 = r[chn][new][j] * cphi - r_prime * cprime;
-	temp2 = r[chn][new][j] * sphi - r_prime * sprime;
+	temp1 = r[chn][fresh][j] * cphi - r_prime * cprime;
+	temp2 = r[chn][fresh][j] * sphi - r_prime * sprime;
       }
 #else
       temp1 =
-	r[chn][new][j] * cos ((double) phi[j]) -
+	r[chn][fresh][j] * cos ((double) phi[j]) -
 	r_prime * cos ((double) phi_prime);
       temp2 =
-	r[chn][new][j] * sin ((double) phi[j]) -
+	r[chn][fresh][j] * sin ((double) phi[j]) -
 	r_prime * sin ((double) phi_prime);
 #endif
 
-      temp3 = r[chn][new][j] + fabs ((double) r_prime);
+      temp3 = r[chn][fresh][j] + fabs ((double) r_prime);
       if (temp3 != 0)
 	c[j] = sqrt (temp1 * temp1 + temp2 * temp2) / temp3;
       else
@@ -419,9 +419,7 @@ void psycho_2_init (double sfreq)
 
 }
 
-void psycho_2_read_absthr (absthr, table)
-     FLOAT *absthr;
-     int table;
+void psycho_2_read_absthr (FLOAT *absthr, int table)
 {
   int j;
 #include "absthr.h"

--- a/psycho_4.c
+++ b/psycho_4.c
@@ -36,12 +36,12 @@ that much difference to the final SNR values, but it's something worth trying
 ****************************************************************/
 
 
-/* The static variables "r", "phi_sav", "new", "old" and "oldest" have    
+/* The static variables "r", "phi_sav", "fresh", "old" and "oldest" have
  to be remembered for the unpredictability measure.  For "r" and        
  "phi_sav", the first index from the left is the channel select and     
  the second index is the "age" of the data.                             */
 
-static int new = 0, old = 1, oldest = 0;
+static int fresh = 0, old = 1, oldest = 0;
 static int init = 0;
 
 /* NMT is a constant 5.5dB. ISO11172 Sec D.2.4.h */
@@ -160,13 +160,13 @@ void psycho_4 (short int *buffer, short int savebuf[1056], int chn,
     psycho_2_fft (wsamp_r, energy, phi);
 
     /* calculate the unpredictability measure, given energy[f] and phi[f] 
-       (the age pointers [new/old/oldest] are reset automatically on the second pass */
+       (the age pointers [fresh/old/oldest] are reset automatically on the second pass */
     {
-      if (new == 0) {
-	new = 1;
+      if (fresh == 0) {
+	fresh = 1;
 	oldest = 1;
       } else {
-	new = 0;
+	fresh = 0;
 	oldest = 0;
       }
       if (old == 0)
@@ -181,22 +181,22 @@ void psycho_4 (short int *buffer, short int savebuf[1056], int chn,
       r_prime = 2.0 * r[chn][old][j] - r[chn][oldest][j];
       phi_prime = 2.0 * phi_sav[chn][old][j] - phi_sav[chn][oldest][j];
 
-      r[chn][new][j] = sqrt ((double) energy[j]);
-      phi_sav[chn][new][j] = phi[j];	
+      r[chn][fresh][j] = sqrt ((double) energy[j]);
+      phi_sav[chn][fresh][j] = phi[j];
   
       {
 	temp1 =
-	  r[chn][new][j] * psycho_4_cos(phi[j]) -
+	  r[chn][fresh][j] * psycho_4_cos(phi[j]) -
 	  r_prime * psycho_4_cos(phi_prime);
 	temp2 =
-	  r[chn][new][j] * psycho_4_sin(phi[j]) -
+	  r[chn][fresh][j] * psycho_4_sin(phi[j]) -
 	  r_prime * psycho_4_sin(phi_prime); 
 	//fprintf(stdout,"[%5.2f %5.2f] [%5.2f %5.2f]\n",temp1, mytemp1, temp2, mytemp2);
 
       }
 
 
-      temp3 = r[chn][new][j] + fabs ((double) r_prime);
+      temp3 = r[chn][fresh][j] + fabs ((double) r_prime);
       if (temp3 != 0)
 	c[j] = sqrt (temp1 * temp1 + temp2 * temp2) / temp3;
       else
@@ -206,18 +206,18 @@ void psycho_4 (short int *buffer, short int savebuf[1056], int chn,
       r_prime = 2.0 * r[chn][old][j] - r[chn][oldest][j];
       phi_prime = 2.0 * phi_sav[chn][old][j] - phi_sav[chn][oldest][j];
 
-      r[chn][new][j] = sqrt ((double) energy[j]);
-      phi_sav[chn][new][j] = phi[j];	
+      r[chn][fresh][j] = sqrt ((double) energy[j]);
+      phi_sav[chn][fresh][j] = phi[j];
 
 
       temp1 =
-	r[chn][new][j] * cos ((double) phi[j]) -
+	r[chn][fresh][j] * cos ((double) phi[j]) -
 	r_prime * cos ((double) phi_prime);
       temp2 =
-	r[chn][new][j] * sin ((double) phi[j]) -
+	r[chn][fresh][j] * sin ((double) phi[j]) -
 	r_prime * sin ((double) phi_prime);      
 
-      temp3 = r[chn][new][j] + fabs ((double) r_prime);
+      temp3 = r[chn][fresh][j] + fabs ((double) r_prime);
       if (temp3 != 0)
 	c[j] = sqrt (temp1 * temp1 + temp2 * temp2) / temp3;
       else

--- a/tables.c
+++ b/tables.c
@@ -57,9 +57,7 @@ int pick_table (frame_info * frame)
  *
  **********************************************************************/
 
-int read_bit_alloc (table, alloc)	/* read in table, return # subbands */
-     int table;
-     al_table *alloc;
+int read_bit_alloc (int table, al_table *alloc)	/* read in table, return # subbands */
 {
 
   static const int startindex_subband[5] = { 0, 290, 592, 674, 788 };

--- a/toolame.c
+++ b/toolame.c
@@ -1,8 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(JACK_INPUT)
 #include <jack/jack.h>
 #include <jack/ringbuffer.h>
+#endif
 #include "common.h"
 #include "encoder.h"
 #include "musicin.h"
@@ -29,6 +31,7 @@
 
 #include <assert.h>
 
+options glopts;
 music_in_t musicin;
 Bit_stream_struc bs;
 char *programName;
@@ -192,7 +195,7 @@ int main (int argc, char **argv)
             return 1;
         }
 
-        xpad_data = malloc(header.dab_length + 1);
+        xpad_data = (uint8_t *)malloc(header.dab_length + 1);
     }
 
     /* this will load the alloc tables and do some other stuff */
@@ -903,9 +906,11 @@ void parse_args (int argc, char **argv, frame_info * frame, int *psy,
                             err = 1;
                         break;
 
+#if defined(JACK_INPUT)
                     case 'j':
                         glopts.input_select = INPUT_SELECT_JACK;
                         break;
+#endif
 
                     case 'b':
                         argUsed = 1;
@@ -977,9 +982,11 @@ void parse_args (int argc, char **argv, frame_info * frame, int *psy,
                         header->mode = MPG_MD_STEREO; /* force stereo mode */
                         header->mode_ext = 0;
                         break;
+#if defined(VLC_INPUT)
                     case 'V':
                         glopts.input_select = INPUT_SELECT_VLC;
                         break;
+#endif
                     case 'W':
                         argUsed = 1;
                         *icy_file = arg;

--- a/vlc_input.c
+++ b/vlc_input.c
@@ -44,7 +44,7 @@ pthread_mutex_t buffer_lock = PTHREAD_MUTEX_INITIALIZER;
 struct vlc_buffer* vlc_buffer_new()
 {
     struct vlc_buffer* node;
-    node = malloc(sizeof(struct vlc_buffer));
+    node = (struct vlc_buffer *)malloc(sizeof(struct vlc_buffer));
     memset(node, 0, sizeof(struct vlc_buffer));
     return node;
 }
@@ -74,7 +74,7 @@ void prepareRender_size_t(
         uint8_t** pp_pcm_buffer,
         size_t size)
 {
-    *pp_pcm_buffer = malloc(size);
+    *pp_pcm_buffer = (uint8_t *)malloc(size);
 }
 
 void prepareRender(
@@ -82,7 +82,7 @@ void prepareRender(
         uint8_t** pp_pcm_buffer,
         unsigned int size)
 {
-    *pp_pcm_buffer = malloc(size);
+    *pp_pcm_buffer = (uint8_t *)malloc(size);
 }
 
 
@@ -290,7 +290,7 @@ ssize_t vlc_in_read(void *buf, size_t len)
 
                 // split the current head into two parts
                 size_t remaining = head_buffer->size - len;
-                uint8_t *newbuf = malloc(remaining);
+                uint8_t *newbuf = (uint8_t *)malloc(remaining);
 
                 memcpy(newbuf, head_buffer->buf + len, remaining);
                 free(head_buffer->buf);
@@ -326,7 +326,7 @@ ssize_t vlc_in_read(void *buf, size_t len)
 // This task is run in a separate thread
 void* vlc_in_write_icy_task(void* arg)
 {
-    struct icywriter_task_data* data = arg;
+    struct icywriter_task_data* data = (struct icywriter_task_data *)arg;
 
     FILE* fd = fopen(vlc_nowplaying_filename, "wb");
     if (fd) {

--- a/zmqoutput.c
+++ b/zmqoutput.c
@@ -73,7 +73,7 @@ int zmqoutput_write_byte(Bit_stream_struc *bs, unsigned char data)
         int frame_length = sizeof(struct zmq_frame_header) + zmqbuf_len;
 
         struct zmq_frame_header* header =
-            malloc(frame_length);
+            (struct zmq_frame_header *)malloc(frame_length);
 
         uint8_t* txframe = ((uint8_t*)header) + sizeof(struct zmq_frame_header);
 


### PR DESCRIPTION
Hi
Update to build with g++ on linux and windows cygwin (g++ needed to link with ZeroMQ on cygwin).
On windows cygwin, compilation and link ok with ZeroMQ and VLC, not tested with jack because I was not able to build jack lib with code::block mingw or cygwin.
Solve a build issue without jack and VLC header files available.

Tested all 14 bitrates at 48 kHz and all 6 psychoacoustic models on linux and windows:
On linux with gcc and g++, all generated files have the same binary content than before my code update (pass 20, fail 0).
On windows cygwin 2.0.4 with g++ 4.9.2, 16 generated files have the same binary content than on linux before my code update (pass 16, fail 4 with parameters: -b 320 -s 48, -b 112 -s 48, -b 256 -y 2 -s 48, -b 256 -y 3 -s 48).
I have not investigated why 4 generated files on windows cygwin have different binary content than on linux because on linux there are no issue.

In the Makefile I have not changed gcc to g++. 
Will let you decide if the change is needed or not.
