### PR TITLE
Include required type libraries if jack not being included

### DIFF
--- a/vlc_input.h
+++ b/vlc_input.h
@@ -4,6 +4,8 @@
 #  if defined(VLC_INPUT)
 
 #include <stdint.h>
+#include <stddef.h>
+#include <sys/types.h>
 #include <vlc/vlc.h>
 
 


### PR DESCRIPTION
If jack libraries are not being compiled into toolame, then inclusion of
stddef.h and sys/types.h libraries is required to get vlc_input.h to
compile